### PR TITLE
Add category filtering to blog model list retrieval

### DIFF
--- a/src/controllers/blog.js
+++ b/src/controllers/blog.js
@@ -23,7 +23,14 @@ module.exports = {
             </ul>
         `
     */
-    const data = await res.getModelList(Blog, {}, [
+
+    let customFilter = {};
+
+    if (req.query?.category) {
+      customFilter = { categoryId: req.query.category };
+    }
+
+    const data = await res.getModelList(Blog, customFilter, [
       "therapistId",
       "categoryId",
     ]);


### PR DESCRIPTION
Implement category filtering in the `getModelList` method of the blog controller to allow fetching models based on the specified category.